### PR TITLE
Fix header import

### DIFF
--- a/Sources/SAMKeychain.h
+++ b/Sources/SAMKeychain.h
@@ -196,4 +196,4 @@ extern NSString *const kSAMKeychainWhereKey;
 
 @end
 
-#import <SAMKeychain/SAMKeychainQuery.h>
+#import "SAMKeychainQuery.h"


### PR DESCRIPTION
Since we don't build a framework, the header should be referenced directly.
